### PR TITLE
Youtube OAuth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,12 +25,12 @@ repositories {
 
 dependencies {
     implementation("org.apache.commons:commons-text:1.10.0")
-    implementation("io.github.cdimascio:dotenv-kotlin:6.4.1")
-    implementation("net.dv8tion:JDA:5.0.0-beta.23")
-    implementation("ch.qos.logback:logback-classic:1.4.5")
-    implementation("dev.arbjerg:lavaplayer:2.2.1") // https://github.com/lavalink-devs/lavaplayer
-    implementation("dev.lavalink.youtube:v2:1.7.2")
-    implementation("org.mongodb:mongodb-driver-sync:4.8.2")
+    implementation("io.github.cdimascio:dotenv-kotlin:6.5.1")
+    implementation("net.dv8tion:JDA:5.3.0")
+    implementation("ch.qos.logback:logback-classic:1.5.16")
+    implementation("dev.arbjerg:lavaplayer:2.2.3") // https://github.com/lavalink-devs/lavaplayer
+    implementation("dev.lavalink.youtube:v2:1.11.4")
+    implementation("org.mongodb:mongodb-driver-sync:5.3.1")
     implementation ("org.scilab.forge:jlatexmath:1.0.7")
 }
 

--- a/src/main/java/com/wylxbot/wylx/Commands/Music/PlayCommand.java
+++ b/src/main/java/com/wylxbot/wylx/Commands/Music/PlayCommand.java
@@ -70,7 +70,7 @@ public class PlayCommand extends ServerCommand {
         Duration dur = Duration.ofSeconds(0);
 
         if (isSearch) {
-            token = "ytsearch:" + event.getMessage().getContentRaw().substring(args[0].length() + 1);
+            token = "ytmsearch:" + event.getMessage().getContentRaw().substring(args[0].length() + 1);
         } else {
             // Replace < and > which avoids embeds on Discord
             token = args[1].replaceAll("(^<)|(>$)", "");

--- a/src/main/java/com/wylxbot/wylx/Core/Music/WylxPlayerManager.java
+++ b/src/main/java/com/wylxbot/wylx/Core/Music/WylxPlayerManager.java
@@ -4,6 +4,7 @@ import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManagers;
+import com.wylxbot.wylx.Wylx;
 import dev.lavalink.youtube.YoutubeAudioSourceManager;
 import dev.lavalink.youtube.clients.*;
 
@@ -25,6 +26,11 @@ public class WylxPlayerManager {
                 new WebEmbeddedWithThumbnail(),
                 new WebWithThumbnail()
         );
+
+        // Youtube source can be given a refresh token to prevent needing to go through the oAuth flow again.
+        // If null is passed, then the user is required to follow the oAuth link found in the logs to login.
+        var cfg = Wylx.getWylxConfig();
+        ytSrcMgr.useOauth2(cfg.oauthRefreshToken, false);
 
         playerManager.registerSourceManager(ytSrcMgr);
 

--- a/src/main/java/com/wylxbot/wylx/Core/WylxEnvConfig.java
+++ b/src/main/java/com/wylxbot/wylx/Core/WylxEnvConfig.java
@@ -8,6 +8,7 @@ public class WylxEnvConfig {
     public final String releaseDiscordToken;
     public final String betaDiscordToken;
     public final String betaPrefix;
+    public final String oauthRefreshToken;
 
     public WylxEnvConfig(Dotenv env) {
         this.release = Boolean.parseBoolean(env.get("RELEASE", "false"));
@@ -15,5 +16,6 @@ public class WylxEnvConfig {
         this.releaseDiscordToken = env.get("DISCORD_TOKEN");
         this.betaDiscordToken = env.get("BETA_DISCORD_TOKEN");
         this.betaPrefix = env.get("BETA_PREFIX");
+        this.oauthRefreshToken = env.get("YT_SRC_OAUTH_REFRESH_TOKEN");
     }
 }


### PR DESCRIPTION
Updated all dependencies
Added OAuth support for youtube authentication. To use this, you have to provide no token for the first time. This will produce a link+code in the logging that will have to be followed. Once logged in, a refresh token is provided that you can provide to Wylx so that you don't have to go through the login flow again.
Tested locally on my own bot.