### PR TITLE
Copy entire repo into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,7 @@ USER gradle:gradle
 
 ARG BUILD_DIR
 WORKDIR $BUILD_DIR
-COPY --chown=gradle:gradle gradlew build.gradle $BUILD_DIR/
-COPY --chown=gradle:gradle src $BUILD_DIR/src
-COPY --chown=gradle:gradle gradle $BUILD_DIR/gradle
-COPY --chown=gradle:gradle .git $BUILD_DIR/.git
+COPY --chown=gradle:gradle . $BUILD_DIR
 RUN ./gradlew build --no-daemon
 
 RUN unzip $BUILD_DIR/build/distributions/wylx.zip -d $BUILD_DIR/unzip


### PR DESCRIPTION
Missed this earlier - git repo shows up as having changes in docker if you don't copy everything in a.k.a I wonder why having half the files missing makes the tree not clean